### PR TITLE
Number extension

### DIFF
--- a/KatLang.ebnf
+++ b/KatLang.ebnf
@@ -88,7 +88,7 @@ ParenBundleExpr = "(" Algorithm ")" ;
 BraceAlgorithmExpr = "{" Algorithm "}" ;
 
 NumberLiteral   = Number ;
-Number          = /\d+(\.\d+)?/ ;
+Number          = /\d(_*\d)*(\.\d(_*\d)*)?(e[+-]?\d(_*\d)*)?/ ;
 NonOutputIdentifier = Identifier ;       (* except reserved definition-position names "Output" and "empty" *)
 Identifier      = /[A-Za-z_][A-Za-z0-9_]*/ ;
 StringLiteral   = /'([^'\r\n])*'/ ;

--- a/src/KatLang/Lexer.cs
+++ b/src/KatLang/Lexer.cs
@@ -48,19 +48,32 @@ public static class Lexer
                 var start = i;
                 var startLine = line;
                 var startCol = col;
-                while (i < source.Length && char.IsDigit(source[i]))
-                { i++; col++; }
+                ScanDigits(source, ref i, ref col);
 
                 // Check for decimal part
                 if (i + 1 < source.Length && source[i] == '.' && char.IsDigit(source[i + 1]))
                 {
                     i++; col++; // skip dot
-                    while (i < source.Length && char.IsDigit(source[i]))
-                    { i++; col++; }
+                    ScanDigits(source, ref i, ref col);
                 }
 
-                var text = source[start..i];
-                if (decimal.TryParse(text, System.Globalization.NumberStyles.Number, System.Globalization.CultureInfo.InvariantCulture, out var value))
+                // Check for scientific notation part (e, optional sign, digits)
+                if (i < source.Length && source[i] == 'e')
+                {
+                    var savedI = i;
+                    var savedCol = col;
+                    i++; col++; // tentatively skip 'e'
+                    if (i < source.Length && (source[i] == '+' || source[i] == '-'))
+                    { i++; col++; }
+                    if (i < source.Length && char.IsDigit(source[i]))
+                        ScanDigits(source, ref i, ref col);
+                    else
+                    { i = savedI; col = savedCol; } // no digit after 'e' — backtrack
+                }
+
+                // Strip digit separators before parsing
+                var text = source[start..i].Replace("_", "");
+                if (decimal.TryParse(text, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var value))
                 {
                     tokens.Add(Token.CreateNumber(value, start, i - start, startLine, startCol));
                 }
@@ -194,5 +207,33 @@ public static class Lexer
 
         tokens.Add(Token.EndOfFile(i, line, col));
         return (tokens, diagnostics);
+    }
+
+    /// <summary>
+    /// Advances <paramref name="i"/> and <paramref name="col"/> past a run of digits, allowing
+    /// underscore digit-separators between digits. Trailing underscores (not followed by a digit)
+    /// are not consumed, preserving the invariant that <c>_</c> only appears between digits.
+    /// </summary>
+    private static void ScanDigits(string source, ref int i, ref int col)
+    {
+        while (i < source.Length && char.IsDigit(source[i]))
+        {
+            i++; col++;
+            // Consume a run of underscores only when a digit follows — enforces
+            // the rule that underscores must appear between digits.
+            if (i < source.Length && source[i] == '_')
+            {
+                var savedI = i;
+                var savedCol = col;
+                while (i < source.Length && source[i] == '_') { i++; col++; }
+                if (i >= source.Length || !char.IsDigit(source[i]))
+                {
+                    // Underscore not followed by a digit: back up, stop scanning.
+                    i = savedI;
+                    col = savedCol;
+                    break;
+                }
+            }
+        }
     }
 }

--- a/tests/KatLang.Tests/LexerTests.cs
+++ b/tests/KatLang.Tests/LexerTests.cs
@@ -297,4 +297,158 @@ public class LexerTests
         // Tokens: Number(2), Slash, Number(0-placeholder), EOF
         Assert.Equal(4, tokens.Count);
     }
+
+    // ── Digit separator (_) tests ────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("1_000",        1000)]
+    [InlineData("1_000_000",    1000000)]
+    [InlineData("1_2_3",        123)]
+    [InlineData("1__2",         12)]
+    [InlineData("9_8_7_6",      9876)]
+    public void Tokenize_IntegerWithUnderscores_ReturnsCorrectValue(string source, decimal expected)
+    {
+        var (tokens, diagnostics) = Lexer.Tokenize(source);
+
+        Assert.Empty(diagnostics);
+        Assert.Equal(TokenKind.Number, tokens[0].Kind);
+        Assert.Equal(expected, tokens[0].NumValue);
+    }
+
+    [Theory]
+    [InlineData("3.14_15",   "3.1415")]
+    [InlineData("1_2.3_4",   "12.34")]
+    [InlineData("0.000_1",   "0.0001")]
+    public void Tokenize_DecimalWithUnderscores_ReturnsCorrectValue(string source, string expectedStr)
+    {
+        var expected = decimal.Parse(expectedStr, System.Globalization.CultureInfo.InvariantCulture);
+        var (tokens, diagnostics) = Lexer.Tokenize(source);
+
+        Assert.Empty(diagnostics);
+        Assert.Equal(TokenKind.Number, tokens[0].Kind);
+        Assert.Equal(expected, tokens[0].NumValue);
+    }
+
+    [Fact]
+    public void Tokenize_TrailingUnderscore_TreatedAsNumberThenIdentifier()
+    {
+        // "1_" → Number(1) then Identifier("_") — trailing _ is not part of the literal
+        var (tokens, diagnostics) = Lexer.Tokenize("1_");
+
+        Assert.Empty(diagnostics);
+        Assert.Equal(TokenKind.Number, tokens[0].Kind);
+        Assert.Equal(1m, tokens[0].NumValue);
+        Assert.Equal(TokenKind.Identifier, tokens[1].Kind);
+        Assert.Equal("_", tokens[1].StringValue);
+    }
+
+    [Fact]
+    public void Tokenize_UnderscoreAdjacentToDecimalPoint_TreatedAsNumberThenIdentifier()
+    {
+        // "1_.2" → Number(1), Identifier("_"), Dot, Number(2) — _ not consumed into literal
+        var (tokens, diagnostics) = Lexer.Tokenize("1_.2");
+
+        Assert.Empty(diagnostics);
+        Assert.Equal(TokenKind.Number, tokens[0].Kind);
+        Assert.Equal(1m, tokens[0].NumValue);
+        Assert.Equal(TokenKind.Identifier, tokens[1].Kind);
+    }
+
+    // ── Scientific notation tests ────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("7e3",    7000)]
+    [InlineData("7e+3",   7000)]
+    [InlineData("1e0",    1)]
+    [InlineData("1e1",    10)]
+    [InlineData("2e10",   20000000000L)]
+    public void Tokenize_ScientificNotation_NonNegativeExponent_ReturnsCorrectValue(string source, decimal expected)
+    {
+        var (tokens, diagnostics) = Lexer.Tokenize(source);
+
+        Assert.Empty(diagnostics);
+        Assert.Equal(TokenKind.Number, tokens[0].Kind);
+        Assert.Equal(expected, tokens[0].NumValue);
+    }
+
+    [Theory]
+    [InlineData("7e-3",   "0.007")]
+    [InlineData("3e-1",   "0.3")]
+    [InlineData("1.5e-2", "0.015")]
+    public void Tokenize_ScientificNotation_NegativeExponent_ReturnsCorrectValue(string source, string expectedStr)
+    {
+        var expected = decimal.Parse(expectedStr, System.Globalization.CultureInfo.InvariantCulture);
+        var (tokens, diagnostics) = Lexer.Tokenize(source);
+
+        Assert.Empty(diagnostics);
+        Assert.Equal(TokenKind.Number, tokens[0].Kind);
+        Assert.Equal(expected, tokens[0].NumValue);
+    }
+
+    [Theory]
+    [InlineData("1.5e2",  150)]
+    [InlineData("2.5e1",  25)]
+    public void Tokenize_ScientificNotation_WithDecimal_ReturnsCorrectValue(string source, decimal expected)
+    {
+        var (tokens, diagnostics) = Lexer.Tokenize(source);
+
+        Assert.Empty(diagnostics);
+        Assert.Equal(TokenKind.Number, tokens[0].Kind);
+        Assert.Equal(expected, tokens[0].NumValue);
+    }
+
+    [Theory]
+    [InlineData("1_0e3",   10000)]
+    [InlineData("1_5e-2",  "0.15")]
+    [InlineData("7e1_0",   70000000000L)]
+    public void Tokenize_ScientificNotation_WithUnderscores_ReturnsCorrectValue(string source, object expectedObj)
+    {
+        var expected = expectedObj is string s
+            ? decimal.Parse(s, System.Globalization.CultureInfo.InvariantCulture)
+            : Convert.ToDecimal(expectedObj);
+        var (tokens, diagnostics) = Lexer.Tokenize(source);
+
+        Assert.Empty(diagnostics);
+        Assert.Equal(TokenKind.Number, tokens[0].Kind);
+        Assert.Equal(expected, tokens[0].NumValue);
+    }
+
+    [Fact]
+    public void Tokenize_UppercaseE_NotScientificNotation()
+    {
+        // Only lowercase 'e' is the scientific notation marker; 'E' starts an identifier
+        var (tokens, diagnostics) = Lexer.Tokenize("7E3");
+
+        Assert.Empty(diagnostics);
+        Assert.Equal(TokenKind.Number,     tokens[0].Kind);
+        Assert.Equal(7m,                   tokens[0].NumValue);
+        Assert.Equal(TokenKind.Identifier, tokens[1].Kind);
+        Assert.Equal("E3",                 tokens[1].StringValue);
+    }
+
+    [Fact]
+    public void Tokenize_EWithNoDigit_BacktracksToPlainNumber()
+    {
+        // "7e" → Number(7) + Identifier("e")
+        var (tokens, diagnostics) = Lexer.Tokenize("7e");
+
+        Assert.Empty(diagnostics);
+        Assert.Equal(TokenKind.Number,     tokens[0].Kind);
+        Assert.Equal(7m,                   tokens[0].NumValue);
+        Assert.Equal(TokenKind.Identifier, tokens[1].Kind);
+        Assert.Equal("e",                  tokens[1].StringValue);
+    }
+
+    [Fact]
+    public void Tokenize_UnderscoreAdjacentToE_NotConsumedIntoLiteral()
+    {
+        // "7e_3" → e is followed by _ (not a digit) → backtrack; "e_3" becomes identifier
+        var (tokens, diagnostics) = Lexer.Tokenize("7e_3");
+
+        Assert.Empty(diagnostics);
+        Assert.Equal(TokenKind.Number,     tokens[0].Kind);
+        Assert.Equal(7m,                   tokens[0].NumValue);
+        Assert.Equal(TokenKind.Identifier, tokens[1].Kind);
+        Assert.Equal("e_3",                tokens[1].StringValue);
+    }
 }


### PR DESCRIPTION
This pull request contains two parts:

(1) Add support for scientific notation (#97) (small case `e` only);
(2) add support for underscores between digits (numeric separators), which allows clear readability for large numbers or numbers with fractional part, a feature available in many languages such as [JavaScript](https://github.com/daumann/ECMAScript-new-features-list/blob/main/ES2021.MD#numeric-separator), [Python](https://peps.python.org/pep-0515/) and [Java](https://docs.oracle.com/javase/8/docs/technotes/guides/language/underscores-literals.html), etc..